### PR TITLE
Allow much larger notes to be loaded

### DIFF
--- a/app/src/main/java/org/houxg/leamonax/Leamonax.java
+++ b/app/src/main/java/org/houxg/leamonax/Leamonax.java
@@ -4,6 +4,7 @@ package org.houxg.leamonax;
 import android.app.Application;
 import android.content.Context;
 import android.content.res.Resources;
+import android.database.CursorWindow;
 import android.text.TextUtils;
 import android.widget.ImageView;
 
@@ -24,6 +25,8 @@ import net.danlew.android.joda.JodaTimeAndroid;
 
 import org.greenrobot.eventbus.EventBus;
 import org.houxg.leamonax.ui.MainActivity;
+
+import java.lang.reflect.Field;
 
 public class Leamonax extends Application {
 
@@ -58,6 +61,14 @@ public class Leamonax extends Application {
                 Glide.with(context).load(path).into(imageView);
             }
         });
+        // Increase allowed size of notes.
+        try {
+            Field field = CursorWindow.class.getDeclaredField("sCursorWindowSize");
+            field.setAccessible(true);
+            field.set(null, 30 * 1024 * 1024); // Allow 30MB notes
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
     private void initBugly() {


### PR DESCRIPTION
I was getting a crash when the app tries to load a new note (made on webui) with a number of images in it:
```
2020-11-30 09:41:50.686 4545-4545/com.leanote.android E/SQLiteQuery: exception: Row too big to fit into CursorWindow requiredPos=236, totalRows=237; query: SELECT * FROM `Note` WHERE `userId`='57edc09449286a0034000001' AND `isDeleted`=0 AND `isTrash`=0
2020-11-30 09:41:50.687 4545-4545/com.leanote.android D/AndroidRuntime: Shutting down VM
2020-11-30 09:41:50.694 4545-4545/com.leanote.android E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.leanote.android, PID: 4545
    org.greenrobot.eventbus.EventBusException: Invoking subscriber failed
        at org.greenrobot.eventbus.EventBus.handleSubscriberException(EventBus.java:505)
        at org.greenrobot.eventbus.EventBus.invokeSubscriber(EventBus.java:487)
        at org.greenrobot.eventbus.EventBus.invokeSubscriber(EventBus.java:479)
        at org.greenrobot.eventbus.HandlerPoster.handleMessage(HandlerPoster.java:67)
        at android.os.Handler.dispatchMessage(Handler.java:107)
        at android.os.Looper.loop(Looper.java:214)
        at android.app.ActivityThread.main(ActivityThread.java:7356)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:491)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:940)
     Caused by: android.database.sqlite.SQLiteBlobTooBigException: Row too big to fit into CursorWindow requiredPos=236, totalRows=237
        at android.database.sqlite.SQLiteConnection.nativeExecuteForCursorWindow(Native Method)
        at android.database.sqlite.SQLiteConnection.executeForCursorWindow(SQLiteConnection.java:942)
        at android.database.sqlite.SQLiteSession.executeForCursorWindow(SQLiteSession.java:838)
        at android.database.sqlite.SQLiteQuery.fillWindow(SQLiteQuery.java:62)
        at android.database.sqlite.SQLiteCursor.fillWindow(SQLiteCursor.java:161)
        at android.database.sqlite.SQLiteCursor.onMove(SQLiteCursor.java:131)
        at android.database.AbstractCursor.moveToPosition(AbstractCursor.java:249)
        at android.database.AbstractCursor.moveToNext(AbstractCursor.java:281)
        at com.raizlabs.android.dbflow.sql.queriable.ListModelLoader.convertToData(ListModelLoader.java:35)
        at com.raizlabs.android.dbflow.sql.queriable.ListModelLoader.convertToData(ListModelLoader.java:15)
        at com.raizlabs.android.dbflow.sql.queriable.ModelLoader.load(ModelLoader.java:69)
        at com.raizlabs.android.dbflow.sql.queriable.ModelLoader.load(ModelLoader.java:57)
        at com.raizlabs.android.dbflow.sql.queriable.ModelLoader.load(ModelLoader.java:51)
        at com.raizlabs.android.dbflow.sql.queriable.ModelLoader.load(ModelLoader.java:35)
        at com.raizlabs.android.dbflow.sql.language.BaseModelQueriable.queryList(BaseModelQueriable.java:53)
        at com.raizlabs.android.dbflow.sql.language.Where.queryList(Where.java:237)
        at org.houxg.leamonax.database.NoteDataStore.getAllNotes(NoteDataStore.java:138)
        at org.houxg.leamonax.ui.NoteFragment.setMode(NoteFragment.java:157)
        at org.houxg.leamonax.ui.MainActivity.onShowNotes(MainActivity.java:181)
        at org.houxg.leamonax.ui.Navigation.refresh(Navigation.java:466)
        at org.houxg.leamonax.ui.MainActivity.onEvent(MainActivity.java:202)
```

This error `SQLiteQuery: exception: Row too big to fit into CursorWindow` is widely reported as a restriction in newer android versions. I implemented this fix from https://github.com/andpor/react-native-sqlite-storage/issues/364#issuecomment-526423153